### PR TITLE
Improve ROS2 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,39 @@ This is a port of official driver https://github.com/Terabee/teraranger to ROS2.
 
 ## Setup
 
-The only dependence is on serial driver:
+- Install serial driver:
 
 ```bash
 sudo apt install ros-humble-serial-driver
 ```
 
-Build it with CMake:
+- Clone and build the repo in ros2 ws
 
 ```bash
-mkdir build && cd build
-cmake ..
-make
-export SERIAL_DEVICE="/dev/ttyACM0"
-./teraranger_ros2_node $SERIAL_DEVICE
+cd ros2_ws/src/
+git clone https://github.com/simutisernestas/teraranger_ros2
+cd ..
+colcon build
 ```
+
+## How to use it
+
+
+```bash
+ros2 run teraranger_ros2 teraranger_ros2_node [--ros-args -p portname:=/dev/ttyACMx]
+```
+
+
+> 📝 Default port: */dev/ttyACM0* 
+
+## Debug
 
 Check the topic:
 ```bash
 ros2 topic echo /teraranger_evo_40m
+```
+
+Check the port in use:
+```bash
+rosparam get /teraranger_ros2_node portname
 ```

--- a/src/teraranger_ros2_node.cpp
+++ b/src/teraranger_ros2_node.cpp
@@ -115,17 +115,14 @@ void serial_port_callback(std::vector<uint8_t> &buffer, const size_t &bytes_tran
 
 int main(int argc, char **argv)
 {
-  // take device and baud rate from argv
-  if (argc < 2)
-  {
-    printf("Usage: %s <device>\n", argv[0]);
-    return 1;
-  }
-  const std::string device = argv[1];
   const uint32_t baud_rate = SERIAL_SPEED;
 
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("teraranger_ros2_node");
+
+  node->declare_parameter("portname", "/dev/ttyACM0");
+  rclcpp::Parameter port_param = node->get_parameter("portname");
+  const std::string device = port_param.as_string();;
 
   const size_t threads_count = 1;
   auto io_context = std::make_unique<drivers::common::IoContext>(threads_count);
@@ -155,8 +152,8 @@ int main(int argc, char **argv)
     msg.header.frame_id = "teraranger_evo_40m";
     msg.radiation_type = sensor_msgs::msg::Range::INFRARED;
     msg.field_of_view = FOV;
-    msg.min_range = EVO_40M_MIN * VALUE_TO_METER_FACTOR;
-    msg.max_range = EVO_40M_MAX * VALUE_TO_METER_FACTOR;
+    msg.min_range = EVO_40M_MIN;
+    msg.max_range = EVO_40M_MAX;
     msg.range = measured_range.load();
     range_pub->publish(msg); });
 


### PR DESCRIPTION
- Set default port and read input from ROS2 param. Also available from command line use (check the mod README file)
- Fix min/max range. Original ROS1 code did not use the VALUE_TO_METER_FACTOR ([ref](https://github.com/Terabee/teraranger/blob/master/src/teraranger_evo.cpp#L64))
- Update README file with new instructions

Everything successfully tested before opening the pull request. Please, have a try before to accept the new changes.